### PR TITLE
fixing private repos not accessible on mvn

### DIFF
--- a/backend/src/commonMain/kotlin/digital/guimauve/pkg/usecases/packages/GetPackageByNameUseCase.kt
+++ b/backend/src/commonMain/kotlin/digital/guimauve/pkg/usecases/packages/GetPackageByNameUseCase.kt
@@ -1,17 +1,21 @@
 package digital.guimauve.pkg.usecases.packages
 
+import dev.kaccelero.commons.exceptions.ControllerException
 import digital.guimauve.pkg.database.packages.IPackagesRepository
 import digital.guimauve.pkg.models.packages.Package
 import digital.guimauve.pkg.models.packages.PackageFormat
 import digital.guimauve.pkg.models.users.User
+import io.ktor.http.*
 
 class GetPackageByNameUseCase(
     private val repository: IPackagesRepository,
 ) : IGetPackageByNameUseCase {
 
-    override suspend fun invoke(input1: String, input2: PackageFormat, input3: User?): Package? =
-        repository.getByName(input1, input2)?.takeIf {
-            it.isPublic || it.organizationId == input3?.organizationId
-        }
+    override suspend fun invoke(input1: String, input2: PackageFormat, input3: User?): Package? {
+        val pkg = repository.getByName(input1, input2) ?: return null
+        if (!pkg.isPublic && pkg.organizationId != input3?.organizationId)
+            throw ControllerException(HttpStatusCode.Unauthorized, "packages_private")
+        return pkg
+    }
 
 }


### PR DESCRIPTION
By default, gradle doesn't send auth headers, so private packages get 404.

We need to reply with a 401 when the package is private so Gradle retries with credentials, and then it works.